### PR TITLE
DEM-62: Fix getFestivals/getFestivalById to return independent copies

### DIFF
--- a/music-festival-planner/ARCHITECTURE.md
+++ b/music-festival-planner/ARCHITECTURE.md
@@ -239,8 +239,8 @@ FestivalService  (providedIn: 'root' — singleton across the app)
 
 | Method | Signature | Returns | Description |
 |---|---|---|---|
-| `getFestivals` | `(): Festival[]` | `Festival[]` | Returns a **shallow copy** of the full list |
-| `getFestivalById` | `(id: string): Festival \| undefined` | `Festival \| undefined` | Finds a single festival by ID |
+| `getFestivals` | `(): Festival[]` | `Festival[]` | Returns an array of **independent copies** (each element spread) |
+| `getFestivalById` | `(id: string): Festival \| undefined` | `Festival \| undefined` | Returns a copy of the matching festival, or `undefined` |
 | `createFestival` | `(data: Omit<Festival, 'id'>): Festival` | `Festival` | Creates a new festival, assigns the next ID, returns a copy |
 | `updateFestival` | `(id: string, updates: Partial<Omit<Festival, 'id'>>): Festival \| null` | `Festival \| null` | Merges updates into the matching festival; returns `null` if not found |
 | `deleteFestival` | `(id: string): boolean` | `boolean` | Removes a festival by ID; returns `true` on success, `false` if not found |
@@ -257,7 +257,7 @@ FestivalService  ──(mutates)──▶  private festivals[]
 Component updates its local view
 ```
 
-> **Note:** The service returns copies (`[...this.festivals]` and `{ ...festival }`) so external code cannot mutate the internal list directly. Future work may replace the in-memory array with HTTP calls or a state management library.
+> **Note:** The service returns copies (`this.festivals.map(f => ({ ...f }))` and `{ ...found }`) so external code cannot mutate the internal list or its elements directly. All `Festival` fields are primitives (`string`/`number`), so a shallow spread is a full copy. Future work may replace the in-memory array with HTTP calls or a state management library.
 
 ---
 

--- a/music-festival-planner/src/app/services/festival.service.ts
+++ b/music-festival-planner/src/app/services/festival.service.ts
@@ -9,11 +9,12 @@ export class FestivalService {
   private nextId = 1;
 
   getFestivals(): Festival[] {
-    return [...this.festivals];
+    return this.festivals.map((f) => ({ ...f }));
   }
 
   getFestivalById(id: string): Festival | undefined {
-    return this.festivals.find((f) => f.id === id);
+    const found = this.festivals.find((f) => f.id === id);
+    return found ? { ...found } : undefined;
   }
 
   createFestival(data: Omit<Festival, 'id'>): Festival {


### PR DESCRIPTION
Callers could previously mutate the service's internal store through the shared object references returned by these two methods.

- getFestivals(): festival.map(f => ({ ...f })) instead of [...this.festivals]
- getFestivalById(): spread the found object instead of returning the reference

Shallow spread is sufficient — all Festival fields are string/number primitives. Also update ARCHITECTURE.md to reflect the corrected copy strategy.

https://claude.ai/code/session_019f3x3QPCfyV3CRpwa718th