### PR TITLE
Add pre-YAML GitHub Pages deployment plan for Angular app in music-festival-planner

### DIFF
--- a/music-festival-planner/GITHUB_PAGES_WORKFLOW_PLAN.md
+++ b/music-festival-planner/GITHUB_PAGES_WORKFLOW_PLAN.md
@@ -1,0 +1,89 @@
+# GitHub Pages Deployment Workflow Plan (Pre-YAML)
+
+This document defines the plan for deploying the Angular app in `music-festival-planner/` to GitHub Pages whenever `main` is updated.
+
+## Goal
+
+- Trigger an automated deployment on pushes to `main`.
+- Build the Angular app from the `music-festival-planner` folder (not repo root).
+- Publish the production build to GitHub Pages.
+
+## Deployment Model
+
+We will use the **official GitHub Pages Actions flow** (artifact-based deployment):
+
+1. `actions/checkout`
+2. `actions/setup-node`
+3. Install dependencies in `music-festival-planner` (`npm ci`)
+4. Build Angular app in production mode
+5. Upload built files as a Pages artifact
+6. Deploy artifact with `actions/deploy-pages`
+
+This avoids manually pushing to `gh-pages` and is GitHub’s recommended approach.
+
+## Trigger & Scope
+
+- Trigger: `push` to `main`
+- Optional manual trigger: `workflow_dispatch`
+- Path scope:
+  - Include only changes that affect the Angular app and workflow files to avoid unnecessary deployments.
+  - Expected filter: `music-festival-planner/**` and `.github/workflows/**`
+
+## Build Folder & Working Directory
+
+Because the Angular project lives in a subfolder, all Node/Angular commands must execute from:
+
+- `music-festival-planner`
+
+Planned workflow default:
+
+- `defaults.run.working-directory: music-festival-planner`
+
+## Base HREF / Routing Requirement
+
+For project pages (`https://<user>.github.io/<repo>/`), Angular needs a matching base path at build time.
+
+Planned default build command:
+
+- `npm run build -- --configuration production --base-href "/${{ github.event.repository.name }}/"`
+
+If this repository is later converted to a **user/org site** (`https://<user>.github.io/`), base href should be changed to `/`.
+
+## Required GitHub Settings
+
+Before/with workflow rollout:
+
+1. Repository **Settings → Pages**
+2. Source = **GitHub Actions**
+3. Ensure workflow has permissions:
+   - `pages: write`
+   - `id-token: write`
+   - `contents: read`
+
+## Runner & Node Version
+
+- Runner: `ubuntu-latest`
+- Node: align with project tooling (`packageManager: npm@11.8.0`), use an LTS runtime supported by Angular 21 (e.g., Node 22).
+- Enable npm cache in setup-node for faster builds.
+
+## Artifact Path
+
+With current Angular builder, production output is expected at:
+
+- `music-festival-planner/dist/music-festival-planner/browser`
+
+The workflow should upload this exact folder as the Pages artifact.
+
+## Validation Checklist (Before Writing YAML)
+
+- [ ] Confirm Pages source is set to GitHub Actions.
+- [ ] Confirm branch name is `main`.
+- [ ] Confirm site type (project page vs user/org page) to lock correct `--base-href`.
+- [ ] Confirm output folder exists after local build.
+
+## Acceptance Criteria for the Future YAML
+
+- On push to `main`, workflow runs automatically.
+- Workflow installs/builds from `music-festival-planner`.
+- Deployment job publishes artifact to GitHub Pages successfully.
+- Deployed app loads without broken assets/routes at the expected Pages URL.

--- a/music-festival-planner/README.md
+++ b/music-festival-planner/README.md
@@ -71,6 +71,7 @@ ng generate service services/<name>
 
 ## Additional Resources
 
+- GitHub Pages deployment plan (pre-workflow): [GITHUB_PAGES_WORKFLOW_PLAN.md](./GITHUB_PAGES_WORKFLOW_PLAN.md)
 - [Angular CLI documentation](https://angular.dev/tools/cli)
 - [Angular 21 docs](https://angular.dev)
 - [Bootstrap 5 docs](https://getbootstrap.com/docs/5.3/)


### PR DESCRIPTION
### Motivation
- Prepare a clear, reviewed plan for deploying the Angular app living in `music-festival-planner/` to GitHub Pages on pushes to `main` before authoring the workflow YAML.
- Capture subfolder build considerations (working directory, base href, artifact path, and required repo permissions) to avoid common deployment mistakes for project pages.

### Description
- Added `music-festival-planner/GITHUB_PAGES_WORKFLOW_PLAN.md` which specifies an artifact-based GitHub Pages flow using `actions/checkout`, `actions/setup-node`, `npm ci`, a production Angular build from the subfolder, and `actions/deploy-pages` for deployment.
- Linked the new plan from `music-festival-planner/README.md` under Additional Resources to make the plan discoverable to contributors.
- Documented trigger (`push` to `main` plus optional `workflow_dispatch`), recommended `defaults.run.working-directory: music-festival-planner`, a suggested build command with `--base-href`, expected artifact path `music-festival-planner/dist/music-festival-planner/browser`, runner/node guidance, repo permissions, and a pre-YAML validation checklist.
- No workflow YAML was added in this change; this is strictly a planning/aligning PR to be followed by the actual workflow implementation.

### Testing
- Ran `npm run build` from `music-festival-planner` to validate the build assumptions, and the build failed due to external font inlining returning HTTP 403 which is an environment/network limitation rather than a code regression.
- No additional automated tests or CI workflows were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1c2d8388c832e9c7041eac819b59e)