### PR TITLE
DEM-93-Add image support to festival cards and update seed data

### DIFF
--- a/music-festival-planner/backend/controllers/festivalController.js
+++ b/music-festival-planner/backend/controllers/festivalController.js
@@ -29,6 +29,7 @@ function mapFestival(festivalDoc) {
     startDate: toDateOnly(festivalDoc.startDate),
     endDate: toDateOnly(festivalDoc.endDate),
     location: festivalDoc.location,
+    imageUrl: festivalDoc.imageUrl || undefined,
     genre: festivalDoc.genre || undefined,
     capacity:
       typeof festivalDoc.capacity === 'number' && festivalDoc.capacity > 0

--- a/music-festival-planner/backend/scripts/seed.js
+++ b/music-festival-planner/backend/scripts/seed.js
@@ -22,7 +22,7 @@ const FESTIVAL_SEED = [
     startDate: new Date('2026-07-18T00:00:00.000Z'),
     endDate: new Date('2026-07-20T23:59:59.000Z'),
     description: 'Three days of electronic, indie, and dance acts by the lake.',
-    imageUrl: 'https://placehold.co/1200x600?text=North+Coast+Pulse',
+    imageUrl: 'https://assets.simpleviewinc.com/simpleview/image/upload/c_fill,f_jpg,h_512,q_65,w_1440/v1/clients/ftlauderdale/Tortuga_Sky_Shot_bea0bd81-94dc-4814-b513-9612e13fc417.jpg',
   },
   {
     name: 'Sunset Echo Weekend 2026',
@@ -30,7 +30,7 @@ const FESTIVAL_SEED = [
     startDate: new Date('2026-09-04T00:00:00.000Z'),
     endDate: new Date('2026-09-06T23:59:59.000Z'),
     description: 'A city-wide weekend festival focused on alt-pop and neo-soul.',
-    imageUrl: 'https://placehold.co/1200x600?text=Sunset+Echo+Weekend',
+    imageUrl: 'https://i0.wp.com/discotech.me/wp-content/uploads/2023/02/sunset-music-festival-tampa-florida.jpg?resize=845%2C321&ssl=1',
   },
 ];
 
@@ -459,7 +459,7 @@ function buildExpandedPerformanceSeed(baseSeed) {
   return expanded;
 }
 
-const EXPANDED_PERFORMANCE_SEED = buildExpandedPerformanceSeed(PERFORMANCE_SEED);
+const EXPANDED_PERFORMANCE_SEED = buildExpandedPerformanceSeed(BASE_PERFORMANCE_SEED);
 
 // Repeatable seeding means clearing old docs before inserting fresh data.
 // Delete order starts from child collections to avoid future FK-like constraints.

--- a/music-festival-planner/src/app/components/festivals/festivals.css
+++ b/music-festival-planner/src/app/components/festivals/festivals.css
@@ -79,6 +79,50 @@
   align-self: flex-start;
 }
 
+.card-visual {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 0.9rem;
+  border: 1px solid var(--border-subtle, rgba(0, 245, 255, 0.15));
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.14), rgba(18, 18, 28, 0.95));
+}
+
+.card-visual-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.card-visual-fallback {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.8rem;
+  text-align: center;
+  color: var(--text-primary, #f0f0f0);
+  background:
+    radial-gradient(circle at 25% 25%, rgba(0, 229, 255, 0.25), transparent 55%),
+    linear-gradient(145deg, rgba(0, 0, 0, 0.35), rgba(0, 229, 255, 0.08));
+}
+
+.card-visual-fallback-icon {
+  font-size: 1.4rem;
+}
+
+.card-visual-fallback-text {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.25;
+  max-width: 20ch;
+}
+
 .card:hover {
   border-color: var(--neon-cyan, #00e5ff);
   box-shadow: 0 0 12px rgba(0, 229, 255, 0.12);
@@ -224,6 +268,20 @@
   margin: 0.2rem 0;
   font-size: 0.9rem;
   color: var(--text-secondary, #a0a0b8);
+}
+
+@media (max-width: 768px) {
+  .card {
+    padding: 1rem;
+  }
+
+  .card-visual {
+    margin-bottom: 0.75rem;
+  }
+
+  .card-visual-fallback-text {
+    font-size: 0.82rem;
+  }
 }
 
 /* ── Card actions (kept for backwards compat) ── */

--- a/music-festival-planner/src/app/components/festivals/festivals.html
+++ b/music-festival-planner/src/app/components/festivals/festivals.html
@@ -9,6 +9,28 @@
       @let festivalStages = stagesByFestivalId[festival.id] ?? [];
       @let stageLoadFailed = stageLoadFailedByFestivalId[festival.id] ?? false;
       <div class="card" [class.card-expanded]="expandedFestivalId === festival.id" role="listitem">
+        <div class="card-visual">
+          @if (hasCardImage(festival)) {
+            <img
+              class="card-visual-image"
+              [src]="festival.imageUrl"
+              [alt]="'Representative image for ' + festival.name + ' in ' + festival.location"
+              loading="lazy"
+              decoding="async"
+              (error)="onCardImageError(festival.id)"
+            />
+          } @else {
+            <div
+              class="card-visual-fallback"
+              role="img"
+              [attr.aria-label]="'No image available. Festival location: ' + festival.location"
+            >
+              <span class="card-visual-fallback-icon" aria-hidden="true">📍</span>
+              <span class="card-visual-fallback-text">{{ festival.location }}</span>
+            </div>
+          }
+        </div>
+
         <div class="card-header">
           <button
             type="button"

--- a/music-festival-planner/src/app/components/festivals/festivals.html
+++ b/music-festival-planner/src/app/components/festivals/festivals.html
@@ -13,7 +13,7 @@
           @if (hasCardImage(festival)) {
             <img
               class="card-visual-image"
-              [src]="festival.imageUrl"
+              [src]="getCardImageUrl(festival) || ''"
               [alt]="'Representative image for ' + festival.name + ' in ' + festival.location"
               loading="lazy"
               decoding="async"

--- a/music-festival-planner/src/app/components/festivals/festivals.spec.ts
+++ b/music-festival-planner/src/app/components/festivals/festivals.spec.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { Festivals } from './festivals';
 import { FestivalService } from '../../services/festival.service';
 import { StageService } from '../../services/stage.service';
+import { Festival } from '../../models/festival.model';
 
 describe('Festivals', () => {
   let component: Festivals;
@@ -24,6 +25,37 @@ describe('Festivals', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('hasCardImage', () => {
+    const baseFestival: Festival = {
+      id: 'fest-1',
+      name: 'Demo Fest',
+      location: 'Austin',
+      startDate: '2026-05-10',
+      endDate: '2026-05-12',
+    };
+
+    it('returns false when imageUrl is missing, blank, or whitespace-only', () => {
+      expect(component.hasCardImage({ ...baseFestival })).toBe(false);
+      expect(component.hasCardImage({ ...baseFestival, imageUrl: '' })).toBe(false);
+      expect(component.hasCardImage({ ...baseFestival, imageUrl: '   ' })).toBe(false);
+    });
+
+    it('returns false after onCardImageError is invoked for a festival', () => {
+      const festivalWithImage = { ...baseFestival, imageUrl: 'https://example.com/fest.jpg' };
+      expect(component.hasCardImage(festivalWithImage)).toBe(true);
+
+      component.onCardImageError(baseFestival.id);
+
+      expect(component.hasCardImage(festivalWithImage)).toBe(false);
+    });
+
+    it('returns true when imageUrl exists and no load error is recorded', () => {
+      const festivalWithImage = { ...baseFestival, imageUrl: ' https://example.com/fest.jpg ' };
+      expect(component.hasCardImage(festivalWithImage)).toBe(true);
+      expect(component.getCardImageUrl(festivalWithImage)).toBe('https://example.com/fest.jpg');
+    });
   });
 
   describe('toggleFestivalCardOnKeyboard', () => {

--- a/music-festival-planner/src/app/components/festivals/festivals.ts
+++ b/music-festival-planner/src/app/components/festivals/festivals.ts
@@ -87,7 +87,12 @@ export class Festivals implements OnInit, OnDestroy {
   }
 
   hasCardImage(festival: Festival): boolean {
-    return !!festival.imageUrl?.trim() && !this.imageLoadFailedByFestivalId[festival.id];
+    return !!this.getCardImageUrl(festival) && !this.imageLoadFailedByFestivalId[festival.id];
+  }
+
+  getCardImageUrl(festival: Festival): string | null {
+    const trimmedImageUrl = festival.imageUrl?.trim();
+    return trimmedImageUrl ? trimmedImageUrl : null;
   }
 
   onCardImageError(festivalId: string): void {

--- a/music-festival-planner/src/app/components/festivals/festivals.ts
+++ b/music-festival-planner/src/app/components/festivals/festivals.ts
@@ -27,6 +27,7 @@ export class Festivals implements OnInit, OnDestroy {
   /** Pre-fetched on init so the template doesn't call the service on every render. */
   stagesByFestivalId: Record<string, Stage[] | undefined> = {};
   stageLoadFailedByFestivalId: Record<string, boolean | undefined> = {};
+  imageLoadFailedByFestivalId: Record<string, boolean | undefined> = {};
 
   openKebabMenuFestivalId: string | null = null;
 
@@ -49,9 +50,11 @@ export class Festivals implements OnInit, OnDestroy {
           this.festivalsList = festivals;
           this.stagesByFestivalId = {};
           this.stageLoadFailedByFestivalId = {};
+          this.imageLoadFailedByFestivalId = {};
 
           festivals.forEach((festival) => {
             this.stageLoadFailedByFestivalId[festival.id] = false;
+            this.imageLoadFailedByFestivalId[festival.id] = false;
           });
 
           if (festivals.length === 0) return of([] as FestivalStageLookup[]);
@@ -78,8 +81,17 @@ export class Festivals implements OnInit, OnDestroy {
           this.festivalsList = [];
           this.stagesByFestivalId = {};
           this.stageLoadFailedByFestivalId = {};
+          this.imageLoadFailedByFestivalId = {};
         },
       });
+  }
+
+  hasCardImage(festival: Festival): boolean {
+    return !!festival.imageUrl?.trim() && !this.imageLoadFailedByFestivalId[festival.id];
+  }
+
+  onCardImageError(festivalId: string): void {
+    this.imageLoadFailedByFestivalId[festivalId] = true;
   }
 
   ngOnInit(): void {

--- a/music-festival-planner/src/app/models/festival.model.ts
+++ b/music-festival-planner/src/app/models/festival.model.ts
@@ -12,6 +12,8 @@ export interface Festival {
   endDate: string;
   /** City, venue, or region where the festival takes place. */
   location: string;
+  /** Optional image URL used for festival card visuals. */
+  imageUrl?: string;
   /** Primary music genre (e.g. "Rock", "Electronic"). Optional. */
   genre?: string;
   /** Maximum total attendee capacity across all stages. Optional. */


### PR DESCRIPTION
DEM-93: Add Festival Card Images with Fallback & Error Handling
Implements festival card images in the festival listing view, including fallback display and error handling for missing or broken image URLs.
What changed:

festivalController.js — exposes the pre-existing imageUrl field from MongoDB through the API response DTO
festival.model.ts — adds optional imageUrl field to the TypeScript Festival interface
festivals.ts — adds imageLoadFailedByFestivalId state map, hasCardImage(), and onCardImageError() to handle image rendering and failure tracking
festivals.html — adds a .card-visual slot at the top of each festival card with conditional image/fallback rendering
festivals.css — adds 16:9 aspect ratio card visual styles, fallback placeholder styles, and a mobile media query
seed.js — replaces placeholder image URLs with real festival photos; fixes a PERFORMANCE_SEED → BASE_PERFORMANCE_SEED reference bug
update-festival-images.js (new) — utility script for updating festival image URLs without a full reseed
package.json — adds festival-images:update npm scripts for local and Atlas environments

Behavior:

Cards display a 16:9 image when festival.imageUrl is populated and loads successfully
Cards fall back to a 📍 location placeholder if the URL is missing or fails to load
Lazy loading and async decoding keep image fetches non-blocking
All existing card interactions (stage expansion, kebab menu, detail navigation) are unaffected

No breaking changes — imageUrl is optional throughout; cards without images degrade gracefully.