### PR TITLE
Dem-97 disable calendar export when schedule clashes exist

### DIFF
--- a/music-festival-planner/src/app/components/my-schedule/my-schedule.css
+++ b/music-festival-planner/src/app/components/my-schedule/my-schedule.css
@@ -356,8 +356,9 @@
 
 .personal-actions {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.6rem;
+  flex-wrap: wrap;
 }
 
 .btn-export-calendar {
@@ -383,6 +384,24 @@
   opacity: 0.65;
 }
 
+.btn-export-calendar-wrap {
+  display: inline-flex;
+}
+
+.calendar-export-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.calendar-clash-msg {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #ffb38a;
+}
+
 .btn-clear-all {
   background: none;
   border: 1px solid rgba(255, 45, 120, 0.35);
@@ -392,6 +411,7 @@
   font-size: 0.78rem;
   padding: 0.3rem 0.85rem;
   transition: background-color 0.15s ease, box-shadow 0.15s ease;
+  align-self: flex-start;
 }
 
 .btn-clear-all:hover {

--- a/music-festival-planner/src/app/components/my-schedule/my-schedule.html
+++ b/music-festival-planner/src/app/components/my-schedule/my-schedule.html
@@ -274,19 +274,33 @@
         performance{{ savedPerformances.length !== 1 ? 's' : '' }} saved
       </p>
       <div class="personal-actions">
-        <button
-          class="btn-export-calendar"
-          (click)="addSavedPerformancesToGoogleCalendar()"
-          [disabled]="calendarExportInProgress"
-          [attr.aria-busy]="calendarExportInProgress"
-          aria-label="Add saved performances to Google Calendar"
-        >
-          @if (calendarExportInProgress) {
-            Connecting...
-          } @else {
-            Add to Google Calendar
+        <div class="calendar-export-group">
+          <span
+            class="btn-export-calendar-wrap"
+            [attr.title]="hasScheduleClashes ? clashDisableReason: null"
+            [attr.aria-label]="hasScheduleClashes ? clashDisableReason: null"
+          >
+            <button
+              class="btn-export-calendar"
+              (click)="addSavedPerformancesToGoogleCalendar()"
+              [disabled]="calendarExportInProgress || hasScheduleClashes"
+              [attr.aria-busy]="calendarExportInProgress"
+              [attr.aria-describedby]="hasScheduleClashes ? 'calendar-clash-msg': null"
+              aria-label="Add saved performances to Google Calendar"
+            >
+              @if (calendarExportInProgress) {
+                Connecting...
+              } @else {
+                Add to Google Calendar
+              }
+            </button>
+          </span>
+          @if (hasScheduleClashes) {
+            <p id="calendar-clash-msg" class="calendar-clash-msg" role="status" aria-live="polite">
+              Resolve clashes before downloading
+            </p>
           }
-        </button>
+        </div>
         <button
           class="btn-clear-all"
           (click)="clearPersonalSchedule()"

--- a/music-festival-planner/src/app/components/my-schedule/my-schedule.spec.ts
+++ b/music-festival-planner/src/app/components/my-schedule/my-schedule.spec.ts
@@ -4,9 +4,13 @@ import { CommonModule } from '@angular/common';
 import { MySchedule, ALL_STAGES } from './my-schedule';
 import { ScheduleService } from '../../services/schedule.service';
 import { FestivalService } from '../../services/festival.service';
-import { PersonalScheduleService } from '../../services/personal-schedule.service';
+import {
+  PersonalScheduleService,
+  PersonalConflict,
+} from '../../services/personal-schedule.service';
+import { CalendarService } from '../../services/calendar.service';
 import { Performance } from '../../models/performance.model';
-import { Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 
 const MOCK_PERFORMANCES: Performance[] = [
   {
@@ -64,11 +68,22 @@ class MockFestivalService {
 }
 
 class MockPersonalScheduleService {
-  saved$ = of([]);
+  private readonly savedSubject = new BehaviorSubject<Performance[]>([]);
+  saved$ = this.savedSubject.asObservable();
+  private conflicts: PersonalConflict[] = [];
+
+  setSaved(saved: Performance[], conflicts: PersonalConflict[] = []): void {
+    this.conflicts = conflicts;
+    this.savedSubject.next(saved.map((p) => ({ ...p })));
+  }
 
   getPersonalConflicts() {
-    return [];
+    return this.conflicts;
   }
+}
+
+class MockCalendarService {
+  beginGoogleCalendarExport = vi.fn();
 }
 
 function makeTestBed(festivalId = '1') {
@@ -83,6 +98,7 @@ function makeTestBed(festivalId = '1') {
       { provide: ScheduleService, useClass: MockScheduleService },
       { provide: FestivalService, useClass: MockFestivalService },
       { provide: PersonalScheduleService, useClass: MockPersonalScheduleService },
+      { provide: CalendarService, useClass: MockCalendarService },
     ],
   }).compileComponents();
 }
@@ -90,11 +106,15 @@ function makeTestBed(festivalId = '1') {
 describe('MySchedule', () => {
   let component: MySchedule;
   let fixture: ComponentFixture<MySchedule>;
+  let personalSchedule: MockPersonalScheduleService;
+  let calendarService: MockCalendarService;
 
   beforeEach(async () => {
     await makeTestBed();
     fixture = TestBed.createComponent(MySchedule);
     component = fixture.componentInstance;
+    personalSchedule = TestBed.inject(PersonalScheduleService) as unknown as MockPersonalScheduleService;
+    calendarService = TestBed.inject(CalendarService) as unknown as MockCalendarService;
     fixture.detectChanges();
     await fixture.whenStable();
   });
@@ -182,6 +202,104 @@ describe('MySchedule', () => {
       component.selectDay('2026-08-01');
       component.selectStage('Forest Stage');
       expect(component.filteredPerformances.length).toBe(0);
+    });
+  });
+
+  describe('calendar export clash protection', () => {
+    it('marks hasScheduleClashes true when personal conflicts exist', () => {
+      const a: Performance = {
+        id: 'p1',
+        festivalId: '1',
+        artistName: 'Act A',
+        stageName: 'Main Stage',
+        date: '2026-08-01',
+        startTime: '18:00',
+        endTime: '19:00',
+      };
+      const b: Performance = {
+        id: 'p2',
+        festivalId: '1',
+        artistName: 'Act B',
+        stageName: 'Dance Tent',
+        date: '2026-08-01',
+        startTime: '18:30',
+        endTime: '19:30',
+      };
+
+      personalSchedule.setSaved([
+        a,
+        b,
+      ], [
+        { a, b, overlapWindow: '06:30 PM–07:00 PM' },
+      ]);
+
+      expect(component.hasScheduleClashes).toBe(true);
+    });
+
+    it('blocks Google Calendar export when clashes exist', () => {
+      const a: Performance = {
+        id: 'p1',
+        festivalId: '1',
+        artistName: 'Act A',
+        stageName: 'Main Stage',
+        date: '2026-08-01',
+        startTime: '18:00',
+        endTime: '19:00',
+      };
+      const b: Performance = {
+        id: 'p2',
+        festivalId: '1',
+        artistName: 'Act B',
+        stageName: 'Dance Tent',
+        date: '2026-08-01',
+        startTime: '18:30',
+        endTime: '19:30',
+      };
+
+      personalSchedule.setSaved([
+        a,
+        b,
+      ], [
+        { a, b, overlapWindow: '06:30 PM–07:00 PM' },
+      ]);
+
+      component.addSavedPerformancesToGoogleCalendar();
+
+      expect(calendarService.beginGoogleCalendarExport).not.toHaveBeenCalled();
+      expect(component.calendarStatusType).toBe('info');
+      expect(component.calendarStatusMessage).toBe('Resolve schedule clashes before downloading');
+    });
+
+    it('re-enables export after clashes are resolved', () => {
+      const a: Performance = {
+        id: 'p1',
+        festivalId: '1',
+        artistName: 'Act A',
+        stageName: 'Main Stage',
+        date: '2026-08-01',
+        startTime: '18:00',
+        endTime: '19:00',
+      };
+      const b: Performance = {
+        id: 'p2',
+        festivalId: '1',
+        artistName: 'Act B',
+        stageName: 'Dance Tent',
+        date: '2026-08-01',
+        startTime: '18:30',
+        endTime: '19:30',
+      };
+
+      personalSchedule.setSaved([
+        a,
+        b,
+      ], [
+        { a, b, overlapWindow: '06:30 PM–07:00 PM' },
+      ]);
+      expect(component.hasScheduleClashes).toBe(true);
+
+      personalSchedule.setSaved([a], []);
+      expect(component.hasScheduleClashes).toBe(false);
     });
   });
 });

--- a/music-festival-planner/src/app/components/my-schedule/my-schedule.ts
+++ b/music-festival-planner/src/app/components/my-schedule/my-schedule.ts
@@ -61,6 +61,9 @@ export class MySchedule implements OnInit, OnDestroy {
 
   conflicts: ConflictInfo[] = [];
 
+  hasScheduleClashes = false;
+  readonly clashDisableReason = 'Resolve schedule clashes before downloading';
+
   savedPerformances: Performance[] = [];
   savedIds: Set<string> = new Set();
   personalConflicts: PersonalConflict[] = [];
@@ -139,6 +142,7 @@ export class MySchedule implements OnInit, OnDestroy {
       this.savedPerformances = saved;
       this.savedIds = new Set(saved.map((p) => p.id));
       this.personalConflicts = this.personalSchedule.getPersonalConflicts();
+      this.hasScheduleClashes = this.personalConflicts.length > 0;
       this.personalDays = [...new Set(saved.map((p) => p.date))].sort();
     });
   }
@@ -231,6 +235,12 @@ export class MySchedule implements OnInit, OnDestroy {
 
   addSavedPerformancesToGoogleCalendar(): void {
     if (this.savedPerformances.length === 0 || this.calendarExportInProgress) {
+      return;
+    }
+
+    if (this.hasScheduleClashes) {
+      this.calendarStatusType = 'info';
+      this.calendarStatusMessage = this.clashDisableReason;
       return;
     }
 
@@ -373,7 +383,6 @@ export class MySchedule implements OnInit, OnDestroy {
     if (existing && /^[A-Za-z0-9_-]{8,128}$/.test(existing)) {
       return existing;
     }
-
     const generated = this.generateDeviceUserId();
     this.storage.setItem(storageKey, generated);
     return generated;


### PR DESCRIPTION
Prevents users from exporting their schedule to Google Calendar when there are unresolved time conflicts, and provides clear feedback to guide them toward resolution.

---

### Changes

**State (`my-schedule.ts`)**
- Added `hasScheduleClashes` and `clashDisableReason` to UI state
- Updated `saved$` subscription to recompute `hasScheduleClashes` reactively whenever saved performances change
- Updated `addSavedPerformancesToGoogleCalendar()` to return early and show an info message (`"Resolve schedule clashes before downloading"`) when clashes are present

**Template (`my-schedule.html`)**
- Export button `disabled` binding now includes `hasScheduleClashes`
- Added `aria-describedby` linking the button to the clash message for accessibility
- Added tooltip/aria-label on the wrapper when disabled due to clashes
- Inline clash message rendered conditionally beneath the button
- Wrapped button + message in a `calendar-export-group` container for layout

**Styles (`my-schedule.css`)**
- `personal-actions` wraps cleanly around updated layout
- Styles added for `btn-export-calendar-wrap`, `calendar-export-group`, and `calendar-clash-msg`

**Tests (`my-schedule.spec.ts`)**
- `sets hasScheduleClashes true when personal conflicts are present`
- `blocks calendar export when clashes exist`
- `re-enables export automatically when clashes are resolved`
- Added mocks for reactive personal schedule updates and calendar service invocation checks