### PR TITLE
Enforce public/admin access separation

### DIFF
--- a/music-festival-planner/backend/.env.example
+++ b/music-festival-planner/backend/.env.example
@@ -16,6 +16,11 @@ PORT=3000
 # Leave empty to allow all origins (development default).
 CORS_ALLOWED_ORIGINS=http://localhost:4200
 
+# Secret used to sign JWT tokens — set to a long random string in production.
+JWT_SECRET=change-me-to-a-long-random-secret
+# Token expiry duration (e.g. 7d, 24h, 1h)
+JWT_EXPIRES_IN=7d
+
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 GOOGLE_OAUTH_REDIRECT_URI=

--- a/music-festival-planner/backend/controllers/authController.js
+++ b/music-festival-planner/backend/controllers/authController.js
@@ -2,10 +2,16 @@ const jwt = require('jsonwebtoken');
 const User = require('../models/user');
 const AppError = require('../middleware/AppError');
 
+const JWT_SECRET = process.env.JWT_SECRET;
+
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not configured.');
+}
+
 function signToken(user) {
   return jwt.sign(
     { id: user._id.toString(), email: user.email, role: user.role },
-    process.env.JWT_SECRET,
+    JWT_SECRET,
     { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
   );
 }

--- a/music-festival-planner/backend/controllers/authController.js
+++ b/music-festival-planner/backend/controllers/authController.js
@@ -1,0 +1,49 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/user');
+const AppError = require('../middleware/AppError');
+
+function signToken(user) {
+  return jwt.sign(
+    { id: user._id.toString(), email: user.email, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
+  );
+}
+
+// POST /api/auth/register
+exports.register = async (req, res, next) => {
+  const { email, password, role } = req.body;
+  try {
+    const existing = await User.findOne({ email });
+    if (existing) return next(new AppError('Email already registered.', 409));
+
+    const user = new User({ email, password, role: role || 'user' });
+    await user.save();
+
+    const token = signToken(user);
+    res.status(201).json({ token, user: { id: user._id, email: user.email, role: user.role } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// POST /api/auth/login
+exports.login = async (req, res, next) => {
+  const { email, password } = req.body;
+  try {
+    const user = await User.findOne({ email }).select('+password');
+    if (!user || !(await user.comparePassword(password))) {
+      return next(new AppError('Invalid email or password.', 401));
+    }
+
+    const token = signToken(user);
+    res.json({ token, user: { id: user._id, email: user.email, role: user.role } });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// GET /api/auth/me  (requires verifyToken middleware)
+exports.me = (req, res) => {
+  res.json({ user: req.user });
+};

--- a/music-festival-planner/backend/controllers/authController.js
+++ b/music-festival-planner/backend/controllers/authController.js
@@ -2,18 +2,18 @@ const jwt = require('jsonwebtoken');
 const User = require('../models/user');
 const AppError = require('../middleware/AppError');
 
-const JWT_SECRET = process.env.JWT_SECRET;
-
-if (!JWT_SECRET) {
-  throw new Error('JWT_SECRET environment variable is not configured.');
+function getJwtSecret() {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new AppError('JWT_SECRET environment variable is not configured.', 500);
+  }
+  return secret;
 }
 
 function signToken(user) {
-  return jwt.sign(
-    { id: user._id.toString(), email: user.email, role: user.role },
-    JWT_SECRET,
-    { expiresIn: process.env.JWT_EXPIRES_IN || '7d' }
-  );
+  return jwt.sign({ id: user._id.toString(), email: user.email, role: user.role }, getJwtSecret(), {
+    expiresIn: process.env.JWT_EXPIRES_IN || '7d',
+  });
 }
 
 // POST /api/auth/register

--- a/music-festival-planner/backend/middleware/auth.js
+++ b/music-festival-planner/backend/middleware/auth.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+const AppError = require('./AppError');
+
+function verifyToken(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next(new AppError('Authentication token required.', 401));
+  }
+  const token = authHeader.slice(7);
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    next();
+  } catch {
+    next(new AppError('Invalid or expired token.', 401));
+  }
+}
+
+function requireAdmin(req, res, next) {
+  if (req.user?.role !== 'admin') {
+    return next(new AppError('Admin access required.', 403));
+  }
+  next();
+}
+
+module.exports = { verifyToken, requireAdmin };

--- a/music-festival-planner/backend/models/user.js
+++ b/music-festival-planner/backend/models/user.js
@@ -30,10 +30,9 @@ const userSchema = new Schema(
   }
 );
 
-userSchema.pre('save', async function hashPassword(next) {
-  if (!this.isModified('password')) return next();
+userSchema.pre('save', async function hashPassword() {
+  if (!this.isModified('password')) return;
   this.password = await bcrypt.hash(this.password, 12);
-  next();
 });
 
 userSchema.methods.comparePassword = function comparePassword(candidate) {

--- a/music-festival-planner/backend/models/user.js
+++ b/music-festival-planner/backend/models/user.js
@@ -1,0 +1,43 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+const { Schema } = mongoose;
+
+const userSchema = new Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    password: {
+      type: String,
+      required: true,
+      minlength: 8,
+      select: false,
+    },
+    role: {
+      type: String,
+      enum: ['user', 'admin'],
+      default: 'user',
+    },
+  },
+  {
+    collection: 'users',
+    timestamps: true,
+  }
+);
+
+userSchema.pre('save', async function hashPassword(next) {
+  if (!this.isModified('password')) return next();
+  this.password = await bcrypt.hash(this.password, 12);
+  next();
+});
+
+userSchema.methods.comparePassword = function comparePassword(candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.models.User || mongoose.model('User', userSchema);

--- a/music-festival-planner/backend/package-lock.json
+++ b/music-festival-planner/backend/package-lock.json
@@ -8,12 +8,14 @@
       "name": "music-festival-planner-backend",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
         "express-rate-limit": "^8.3.2",
         "googleapis": "^171.4.0",
         "joi": "^18.1.2",
+        "jsonwebtoken": "^9.0.3",
         "mongoose": "^8.23.0"
       },
       "devDependencies": {
@@ -172,6 +174,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -1037,6 +1048,34 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -1066,6 +1105,48 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1575,7 +1656,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/music-festival-planner/backend/package.json
+++ b/music-festival-planner/backend/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "seed": "node scripts/seed.js",
+    "seed:admin": "node scripts/seed-admin.js",
     "seed:local": "node -e \"process.env.MONGODB_ENV_FILE='.env.local'; require('./scripts/seed');\"",
     "seed:atlas": "node -e \"process.env.MONGODB_ENV_FILE='.env.atlas'; require('./scripts/seed');\"",
     "seed:reset": "node scripts/seed.js --reset --confirm WIPE",

--- a/music-festival-planner/backend/package.json
+++ b/music-festival-planner/backend/package.json
@@ -18,12 +18,14 @@
     "use-atlas-db": "node -e \"require('fs').copyFileSync('.env.atlas','.env'); console.log('Switched to Atlas MongoDB (.env.atlas -> .env)');\""
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
     "express-rate-limit": "^8.3.2",
     "googleapis": "^171.4.0",
     "joi": "^18.1.2",
+    "jsonwebtoken": "^9.0.3",
     "mongoose": "^8.23.0"
   },
   "devDependencies": {

--- a/music-festival-planner/backend/routes/auth.js
+++ b/music-festival-planner/backend/routes/auth.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/authController');
+const validate = require('../middleware/validate');
+const { verifyToken } = require('../middleware/auth');
+const { registerSchema, loginSchema } = require('../validators/authSchemas');
+
+router.post('/register', validate(registerSchema), controller.register);
+router.post('/login', validate(loginSchema), controller.login);
+router.get('/me', verifyToken, controller.me);
+
+module.exports = router;

--- a/music-festival-planner/backend/scripts/seed-admin.js
+++ b/music-festival-planner/backend/scripts/seed-admin.js
@@ -1,0 +1,54 @@
+const { connectToDatabase, disconnectFromDatabase } = require('../config/database');
+const User = require('../models/user');
+
+// Usage:
+//   ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=yourpassword node scripts/seed-admin.js
+//
+// Both values must be supplied via environment variables (set them in your .env
+// file or inline on the command line).  The script is idempotent: if the email
+// already exists it updates the role to 'admin' without changing the password.
+
+async function run() {
+  const email = process.env.ADMIN_EMAIL;
+  const password = process.env.ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    console.error('Error: ADMIN_EMAIL and ADMIN_PASSWORD environment variables are required.');
+    console.error('Example: ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=secret node scripts/seed-admin.js');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (password.length < 8) {
+    console.error('Error: ADMIN_PASSWORD must be at least 8 characters.');
+    process.exitCode = 1;
+    return;
+  }
+
+  await connectToDatabase();
+
+  try {
+    const existing = await User.findOne({ email });
+
+    if (existing) {
+      if (existing.role === 'admin') {
+        console.log(`Admin account already exists for ${email}. Nothing to do.`);
+      } else {
+        existing.role = 'admin';
+        await existing.save();
+        console.log(`Updated existing user ${email} to role 'admin'.`);
+      }
+    } else {
+      const user = new User({ email, password, role: 'admin' });
+      await user.save();
+      console.log(`Admin account created for ${email}.`);
+    }
+  } finally {
+    await disconnectFromDatabase();
+  }
+}
+
+run().catch((err) => {
+  console.error('seed-admin failed:', err);
+  process.exitCode = 1;
+});

--- a/music-festival-planner/backend/server.js
+++ b/music-festival-planner/backend/server.js
@@ -86,8 +86,18 @@ app.get('/', (_req, res) => {
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
 // Rate-limit all API routes.
-app.use('/api/auth', authLimiter, authRouter);
 app.use('/api', apiLimiter);
+app.use(
+  '/api/auth',
+  (req, res, next) => {
+    if (req.method === 'GET' && req.path === '/me') {
+      return next();
+    }
+
+    return authLimiter(req, res, next);
+  },
+  authRouter,
+);
 app.use('/api/festivals', festivalsRouter);
 app.use('/api/stages', stagesRouter);
 app.use('/api/performances', performancesRouter);

--- a/music-festival-planner/backend/server.js
+++ b/music-festival-planner/backend/server.js
@@ -20,9 +20,10 @@ const festivalsRouter = require('./routes/festivals');
 const stagesRouter = require('./routes/stages');
 const performancesRouter = require('./routes/performances');
 const calendarRouter = require('./routes/calendar');
+const authRouter = require('./routes/auth');
 
 const requestLogger = require('./middleware/requestLogger');
-const { apiLimiter } = require('./middleware/rateLimiter');
+const { apiLimiter, authLimiter } = require('./middleware/rateLimiter');
 const notFound = require('./middleware/notFound');
 const errorHandler = require('./middleware/errorHandler');
 
@@ -85,7 +86,7 @@ app.get('/', (_req, res) => {
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
 // Rate-limit all API routes.
-// Apply authLimiter (from middleware/rateLimiter.js) to POST /api/auth/* when auth routes are added.
+app.use('/api/auth', authLimiter, authRouter);
 app.use('/api', apiLimiter);
 app.use('/api/festivals', festivalsRouter);
 app.use('/api/stages', stagesRouter);

--- a/music-festival-planner/backend/server.js
+++ b/music-festival-planner/backend/server.js
@@ -12,8 +12,16 @@
  * The server listens on the PORT env variable (default 3000).
  */
 
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
 const express = require('express');
 const cors = require('cors');
+
+const envPath = fs.existsSync(path.join(__dirname, '.env.local'))
+  ? path.join(__dirname, '.env.local')
+  : path.join(__dirname, '.env');
+dotenv.config({ path: envPath });
 
 const { connectToDatabase } = require('./config/database');
 const festivalsRouter = require('./routes/festivals');

--- a/music-festival-planner/backend/validators/authSchemas.js
+++ b/music-festival-planner/backend/validators/authSchemas.js
@@ -1,0 +1,14 @@
+const Joi = require('joi');
+
+const registerSchema = Joi.object({
+  email: Joi.string().email().lowercase().trim().required(),
+  password: Joi.string().min(8).max(128).required(),
+  role: Joi.string().valid('user', 'admin'),
+});
+
+const loginSchema = Joi.object({
+  email: Joi.string().email().lowercase().trim().required(),
+  password: Joi.string().required(),
+});
+
+module.exports = { registerSchema, loginSchema };

--- a/music-festival-planner/backend/validators/authSchemas.js
+++ b/music-festival-planner/backend/validators/authSchemas.js
@@ -3,7 +3,6 @@ const Joi = require('joi');
 const registerSchema = Joi.object({
   email: Joi.string().email().lowercase().trim().required(),
   password: Joi.string().min(8).max(128).required(),
-  role: Joi.string().valid('user', 'admin'),
 });
 
 const loginSchema = Joi.object({

--- a/music-festival-planner/src/app/app-module.ts
+++ b/music-festival-planner/src/app/app-module.ts
@@ -1,7 +1,7 @@
 import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { LocationStrategy, HashLocationStrategy } from '@angular/common';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing-module';
 import { App } from './app';
 import { Home } from './components/home/home';
@@ -13,6 +13,9 @@ import { StageCreateComponent } from './components/stage-create/stage-create';
 import { StageListComponent } from './components/stage-list/stage-list';
 import { PerformanceListComponent } from './components/performance-list/performance-list';
 import { PerformanceCreateComponent } from './components/performance-create/performance-create';
+import { LoginComponent } from './components/login/login';
+import { AdminDashboardComponent } from './components/admin-dashboard/admin-dashboard';
+import { authInterceptor } from './interceptors/auth.interceptor';
 
 @NgModule({
   declarations: [
@@ -25,11 +28,13 @@ import { PerformanceCreateComponent } from './components/performance-create/perf
     StageListComponent,
     PerformanceListComponent,
     PerformanceCreateComponent,
+    LoginComponent,
+    AdminDashboardComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, ReactiveFormsModule],
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
     { provide: LocationStrategy, useClass: HashLocationStrategy },
   ],
   bootstrap: [App],

--- a/music-festival-planner/src/app/app-routing-module.ts
+++ b/music-festival-planner/src/app/app-routing-module.ts
@@ -8,9 +8,14 @@ import { StageListComponent } from './components/stage-list/stage-list';
 import { StageCreateComponent } from './components/stage-create/stage-create';
 import { PerformanceListComponent } from './components/performance-list/performance-list';
 import { PerformanceCreateComponent } from './components/performance-create/performance-create';
+import { LoginComponent } from './components/login/login';
+import { AdminDashboardComponent } from './components/admin-dashboard/admin-dashboard';
+import { adminGuard } from './guards/admin.guard';
 
 const routes: Routes = [
   { path: '', component: Home },
+  { path: 'login', component: LoginComponent },
+  { path: 'admin', component: AdminDashboardComponent, canActivate: [adminGuard] },
   { path: 'festivals', component: Festivals },
   { path: 'festivals/create', component: FestivalCreateComponent },
   { path: 'my-schedule', component: MySchedule },

--- a/music-festival-planner/src/app/app-routing-module.ts
+++ b/music-festival-planner/src/app/app-routing-module.ts
@@ -17,13 +17,13 @@ const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'admin', component: AdminDashboardComponent, canActivate: [adminGuard] },
   { path: 'festivals', component: Festivals },
-  { path: 'festivals/create', component: FestivalCreateComponent },
+  { path: 'festivals/create', component: FestivalCreateComponent, canActivate: [adminGuard] },
   { path: 'my-schedule', component: MySchedule },
   { path: 'festivals/:id/schedule', component: MySchedule },
-  { path: 'festivals/:id/stages', component: StageListComponent },
-  { path: 'festivals/:id/stages/new', component: StageCreateComponent },
-  { path: 'festivals/:id/performances', component: PerformanceListComponent },
-  { path: 'festivals/:id/performances/new', component: PerformanceCreateComponent },
+  { path: 'festivals/:id/stages', component: StageListComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/stages/new', component: StageCreateComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/performances', component: PerformanceListComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/performances/new', component: PerformanceCreateComponent, canActivate: [adminGuard] },
   { path: '**', redirectTo: '' },
 ];
 

--- a/music-festival-planner/src/app/app.html
+++ b/music-festival-planner/src/app/app.html
@@ -25,10 +25,7 @@
       <li class="nav-item" *ngIf="authService.isLoggedIn">
         <span class="nav-link text-muted">{{ authService.currentUser?.email }}</span>
       </li>
-      <li class="nav-item" *ngIf="!authService.isLoggedIn">
-        <a class="nav-link" routerLink="/login">Sign In</a>
-      </li>
-      <li class="nav-item" *ngIf="authService.isLoggedIn">
+<li class="nav-item" *ngIf="authService.isLoggedIn">
         <button class="btn btn-link nav-link" (click)="logout()">Sign Out</button>
       </li>
     </ul>

--- a/music-festival-planner/src/app/app.html
+++ b/music-festival-planner/src/app/app.html
@@ -4,7 +4,7 @@
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="navbarNav">
-    <ul class="navbar-nav">
+    <ul class="navbar-nav me-auto">
       <li class="nav-item">
         <a class="nav-link" routerLink="/">Home</a>
       </li>
@@ -13,6 +13,23 @@
       </li>
       <li class="nav-item">
         <a class="nav-link" routerLink="/my-schedule">My Schedule</a>
+      </li>
+      <li class="nav-item" *ngIf="authService.isAdmin">
+        <a class="nav-link" routerLink="/admin">
+          <span class="badge bg-danger me-1">Admin</span>Dashboard
+        </a>
+      </li>
+    </ul>
+
+    <ul class="navbar-nav ms-auto">
+      <li class="nav-item" *ngIf="authService.isLoggedIn">
+        <span class="nav-link text-muted">{{ authService.currentUser?.email }}</span>
+      </li>
+      <li class="nav-item" *ngIf="!authService.isLoggedIn">
+        <a class="nav-link" routerLink="/login">Sign In</a>
+      </li>
+      <li class="nav-item" *ngIf="authService.isLoggedIn">
+        <button class="btn btn-link nav-link" (click)="logout()">Sign Out</button>
       </li>
     </ul>
   </div>

--- a/music-festival-planner/src/app/app.ts
+++ b/music-festival-planner/src/app/app.ts
@@ -1,11 +1,23 @@
 import { Component, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from './services/auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.html',
   standalone: false,
-  styleUrl: './app.css'
+  styleUrl: './app.css',
 })
 export class App {
   protected readonly title = signal('music-festival-planner');
+
+  constructor(
+    public authService: AuthService,
+    private router: Router,
+  ) {}
+
+  logout(): void {
+    this.authService.logout();
+    this.router.navigate(['/']);
+  }
 }

--- a/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.css
+++ b/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.css
@@ -1,0 +1,3 @@
+.admin-dashboard {
+  padding-top: 2rem;
+}

--- a/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.html
+++ b/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.html
@@ -1,0 +1,42 @@
+<div class="admin-dashboard">
+  <div class="d-flex align-items-center mb-4">
+    <h1 class="mb-0 me-3">Admin Dashboard</h1>
+    <span class="badge bg-danger">Admin</span>
+  </div>
+
+  <p class="text-muted mb-4">
+    Logged in as <strong>{{ authService.currentUser?.email }}</strong>
+  </p>
+
+  <div class="row g-4">
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm">
+        <div class="card-body">
+          <h5 class="card-title">Festival Management</h5>
+          <p class="card-text text-muted">Create, edit, and delete festivals.</p>
+          <a routerLink="/festivals/create" class="btn btn-primary">Create Festival</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm">
+        <div class="card-body">
+          <h5 class="card-title">Browse Festivals</h5>
+          <p class="card-text text-muted">View all festivals and manage stages and performances.</p>
+          <a routerLink="/festivals" class="btn btn-outline-primary">View Festivals</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm">
+        <div class="card-body">
+          <h5 class="card-title">Schedule Overview</h5>
+          <p class="card-text text-muted">Review the full festival schedule.</p>
+          <a routerLink="/my-schedule" class="btn btn-outline-primary">View Schedule</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.ts
+++ b/music-festival-planner/src/app/components/admin-dashboard/admin-dashboard.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: false,
+  templateUrl: './admin-dashboard.html',
+  styleUrl: './admin-dashboard.css',
+})
+export class AdminDashboardComponent {
+  constructor(public authService: AuthService) {}
+}

--- a/music-festival-planner/src/app/components/festivals/festivals.html
+++ b/music-festival-planner/src/app/components/festivals/festivals.html
@@ -1,7 +1,9 @@
 <div class="festivals-container" (click)="closeAllKebabMenus()">
   <nav class="page-nav">
     <h1 id="festivals-heading">Music Festivals</h1>
-    <button class="btn-primary" routerLink="/festivals/create">+ Add New Festival</button>
+    @if (isOrganizerUser) {
+      <button class="btn-primary" routerLink="/festivals/create">+ Add New Festival</button>
+    }
   </nav>
 
   <div class="card-grid" role="list" aria-labelledby="festivals-heading">
@@ -162,9 +164,14 @@
 
   @if (festivalsList.length === 0) {
     <div class="empty-state">
-      <h2>No festivals yet</h2>
-      <p>Add your first festival to start building schedules, stages, and performances.</p>
-      <button class="btn-primary" routerLink="/festivals/create">Create your first festival</button>
+      @if (isOrganizerUser) {
+        <h2>No festivals yet</h2>
+        <p>Add your first festival to start building schedules, stages, and performances.</p>
+        <button class="btn-primary" routerLink="/festivals/create">Create your first festival</button>
+      } @else {
+        <h2>No festivals yet</h2>
+        <p>Check back soon — festivals will be listed here once they are added.</p>
+      }
     </div>
   }
 </div>

--- a/music-festival-planner/src/app/components/festivals/festivals.ts
+++ b/music-festival-planner/src/app/components/festivals/festivals.ts
@@ -5,6 +5,7 @@ import { catchError, filter, switchMap } from 'rxjs/operators';
 import { FestivalService } from '../../services/festival.service';
 import { StageService } from '../../services/stage.service';
 import { PersonalScheduleService } from '../../services/personal-schedule.service';
+import { AuthService } from '../../services/auth.service';
 import { Festival } from '../../models/festival.model';
 import { Stage } from '../../models/stage.model';
 
@@ -19,8 +20,9 @@ type FestivalStageLookup = { id: string; stages: Stage[]; failed: boolean };
 export class Festivals implements OnInit, OnDestroy {
   festivalsList: Festival[] = [];
 
-  /** Stub: swap with a real auth service when authentication is added. */
-  isOrganizerUser = true;
+  get isOrganizerUser(): boolean {
+    return this.authService.isAdmin;
+  }
 
   expandedFestivalId: string | null = null;
 
@@ -38,6 +40,7 @@ export class Festivals implements OnInit, OnDestroy {
     private festivalService: FestivalService,
     private stageService: StageService,
     private personalScheduleService: PersonalScheduleService,
+    private authService: AuthService,
     private router: Router,
   ) {}
 

--- a/music-festival-planner/src/app/components/login/login.css
+++ b/music-festival-planner/src/app/components/login/login.css
@@ -1,0 +1,11 @@
+.login-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 4rem;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+}

--- a/music-festival-planner/src/app/components/login/login.html
+++ b/music-festival-planner/src/app/components/login/login.html
@@ -1,0 +1,52 @@
+<div class="login-wrapper">
+  <div class="login-card card shadow-sm">
+    <div class="card-body p-4">
+      <h2 class="card-title text-center mb-4">Sign In</h2>
+
+      <div *ngIf="errorMessage" class="alert alert-danger" role="alert">
+        {{ errorMessage }}
+      </div>
+
+      <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+        <div class="mb-3">
+          <label for="email" class="form-label">Email address</label>
+          <input
+            id="email"
+            type="email"
+            class="form-control"
+            [class.is-invalid]="form.get('email')?.invalid && form.get('email')?.touched"
+            formControlName="email"
+            autocomplete="email"
+          />
+          <div class="invalid-feedback">
+            Please enter a valid email address.
+          </div>
+        </div>
+
+        <div class="mb-4">
+          <label for="password" class="form-label">Password</label>
+          <input
+            id="password"
+            type="password"
+            class="form-control"
+            [class.is-invalid]="form.get('password')?.invalid && form.get('password')?.touched"
+            formControlName="password"
+            autocomplete="current-password"
+          />
+          <div class="invalid-feedback">
+            Password must be at least 8 characters.
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          class="btn btn-primary w-100"
+          [disabled]="form.invalid || isLoading"
+        >
+          <span *ngIf="isLoading" class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+          {{ isLoading ? 'Signing in…' : 'Sign In' }}
+        </button>
+      </form>
+    </div>
+  </div>
+</div>

--- a/music-festival-planner/src/app/components/login/login.ts
+++ b/music-festival-planner/src/app/components/login/login.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: false,
+  templateUrl: './login.html',
+  styleUrl: './login.css',
+})
+export class LoginComponent implements OnInit {
+  form!: FormGroup;
+  errorMessage = '';
+  isLoading = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    if (this.authService.isLoggedIn) {
+      this.router.navigate(['/']);
+      return;
+    }
+    this.form = this.fb.group({
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.isLoading) return;
+    this.errorMessage = '';
+    this.isLoading = true;
+
+    const { email, password } = this.form.value;
+    this.authService.login(email, password).subscribe({
+      next: () => {
+        const destination = this.authService.isAdmin ? '/admin' : '/festivals';
+        this.router.navigate([destination]);
+      },
+      error: (err: Error) => {
+        this.errorMessage = err.message;
+        this.isLoading = false;
+      },
+    });
+  }
+}

--- a/music-festival-planner/src/app/guards/admin.guard.ts
+++ b/music-festival-planner/src/app/guards/admin.guard.ts
@@ -1,0 +1,11 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const adminGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isAdmin) return true;
+  if (!auth.isLoggedIn) return router.createUrlTree(['/login']);
+  return router.createUrlTree(['/']);
+};

--- a/music-festival-planner/src/app/guards/auth.guard.ts
+++ b/music-festival-planner/src/app/guards/auth.guard.ts
@@ -1,0 +1,10 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isLoggedIn) return true;
+  return router.createUrlTree(['/login']);
+};

--- a/music-festival-planner/src/app/interceptors/auth.interceptor.ts
+++ b/music-festival-planner/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,11 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};

--- a/music-festival-planner/src/app/models/user.model.ts
+++ b/music-festival-planner/src/app/models/user.model.ts
@@ -1,0 +1,12 @@
+export type UserRole = 'user' | 'admin';
+
+export interface User {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: User;
+}

--- a/music-festival-planner/src/app/services/auth.service.ts
+++ b/music-festival-planner/src/app/services/auth.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, tap, throwError, catchError } from 'rxjs';
+import { User, AuthResponse } from '../models/user.model';
+import { environment } from '../../environments/environment';
+
+const TOKEN_KEY = 'mfp_auth_token';
+const USER_KEY = 'mfp_auth_user';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly apiUrl = `${environment.apiUrl}/api/auth`;
+
+  private currentUserSubject = new BehaviorSubject<User | null>(this.loadStoredUser());
+  currentUser$ = this.currentUserSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  get currentUser(): User | null {
+    return this.currentUserSubject.value;
+  }
+
+  get isLoggedIn(): boolean {
+    return this.currentUser !== null;
+  }
+
+  get isAdmin(): boolean {
+    return this.currentUser?.role === 'admin';
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  login(email: string, password: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.apiUrl}/login`, { email, password }).pipe(
+      tap((res) => this.storeSession(res)),
+      catchError(this.handleError)
+    );
+  }
+
+  register(email: string, password: string, role?: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.apiUrl}/register`, { email, password, role }).pipe(
+      tap((res) => this.storeSession(res)),
+      catchError(this.handleError)
+    );
+  }
+
+  logout(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+    this.currentUserSubject.next(null);
+  }
+
+  private storeSession(res: AuthResponse): void {
+    localStorage.setItem(TOKEN_KEY, res.token);
+    localStorage.setItem(USER_KEY, JSON.stringify(res.user));
+    this.currentUserSubject.next(res.user);
+  }
+
+  private loadStoredUser(): User | null {
+    try {
+      const raw = localStorage.getItem(USER_KEY);
+      return raw ? (JSON.parse(raw) as User) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private handleError(err: { error?: { message?: string }; message?: string }): Observable<never> {
+    const message = err?.error?.message ?? err?.message ?? 'An unexpected error occurred.';
+    return throwError(() => new Error(message));
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Hide Sign In link** from the public navbar — the login page is not discoverable by regular users; admins navigate to `/login` directly
- **Guard all admin-only routes** with `adminGuard`: `festivals/create`, `festivals/:id/stages`, `festivals/:id/stages/new`, `festivals/:id/performances`, `festivals/:id/performances/new` — unauthenticated visitors are redirected to `/login`, non-admin logged-in users are sent to `/`
- **Hide admin-only UI** on the festivals page: the `+ Add New Festival` button and the empty-state `Create your first festival` button are now only rendered for admin users; public users see a friendly "Check back soon" message when no festivals exist
- **Add `seed-admin.js` script** to the backend so the first admin account can be created: `ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=yourpassword npm run seed:admin`

## Test plan

- [ ] Visit `/festivals` as a public (unauthenticated) user — confirm no `+ Add New Festival` button and no 3-dot kebab menus on cards
- [ ] Navigate to `/festivals/create` without being logged in — confirm redirect to `/login`
- [ ] Navigate to `/festivals/<id>/stages` without being logged in — confirm redirect to `/login`
- [ ] Log in as admin — confirm `+ Add New Festival` button and kebab menus reappear
- [ ] Confirm Sign In link is gone from the public navbar; admin can still reach `/login` by typing it directly
- [ ] Run `ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=password123 npm run seed:admin` inside `backend/` and confirm the admin account is created in MongoDB

https://claude.ai/code/session_01T8iXFEuLauZdGpfSbDw2Bt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8iXFEuLauZdGpfSbDw2Bt)_