### PR TITLE
Enforce public/admin access separation across the app

### DIFF
--- a/music-festival-planner/backend/package.json
+++ b/music-festival-planner/backend/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "seed": "node scripts/seed.js",
+    "seed:admin": "node scripts/seed-admin.js",
     "seed:local": "node -e \"process.env.MONGODB_ENV_FILE='.env.local'; require('./scripts/seed');\"",
     "seed:atlas": "node -e \"process.env.MONGODB_ENV_FILE='.env.atlas'; require('./scripts/seed');\"",
     "seed:reset": "node scripts/seed.js --reset --confirm WIPE",

--- a/music-festival-planner/backend/scripts/seed-admin.js
+++ b/music-festival-planner/backend/scripts/seed-admin.js
@@ -1,0 +1,54 @@
+const { connectToDatabase, disconnectFromDatabase } = require('../config/database');
+const User = require('../models/user');
+
+// Usage:
+//   ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=yourpassword node scripts/seed-admin.js
+//
+// Both values must be supplied via environment variables (set them in your .env
+// file or inline on the command line).  The script is idempotent: if the email
+// already exists it updates the role to 'admin' without changing the password.
+
+async function run() {
+  const email = process.env.ADMIN_EMAIL;
+  const password = process.env.ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    console.error('Error: ADMIN_EMAIL and ADMIN_PASSWORD environment variables are required.');
+    console.error('Example: ADMIN_EMAIL=admin@example.com ADMIN_PASSWORD=secret node scripts/seed-admin.js');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (password.length < 8) {
+    console.error('Error: ADMIN_PASSWORD must be at least 8 characters.');
+    process.exitCode = 1;
+    return;
+  }
+
+  await connectToDatabase();
+
+  try {
+    const existing = await User.findOne({ email });
+
+    if (existing) {
+      if (existing.role === 'admin') {
+        console.log(`Admin account already exists for ${email}. Nothing to do.`);
+      } else {
+        existing.role = 'admin';
+        await existing.save();
+        console.log(`Updated existing user ${email} to role 'admin'.`);
+      }
+    } else {
+      const user = new User({ email, password, role: 'admin' });
+      await user.save();
+      console.log(`Admin account created for ${email}.`);
+    }
+  } finally {
+    await disconnectFromDatabase();
+  }
+}
+
+run().catch((err) => {
+  console.error('seed-admin failed:', err);
+  process.exitCode = 1;
+});

--- a/music-festival-planner/src/app/app-routing-module.ts
+++ b/music-festival-planner/src/app/app-routing-module.ts
@@ -17,13 +17,13 @@ const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: 'admin', component: AdminDashboardComponent, canActivate: [adminGuard] },
   { path: 'festivals', component: Festivals },
-  { path: 'festivals/create', component: FestivalCreateComponent },
+  { path: 'festivals/create', component: FestivalCreateComponent, canActivate: [adminGuard] },
   { path: 'my-schedule', component: MySchedule },
   { path: 'festivals/:id/schedule', component: MySchedule },
-  { path: 'festivals/:id/stages', component: StageListComponent },
-  { path: 'festivals/:id/stages/new', component: StageCreateComponent },
-  { path: 'festivals/:id/performances', component: PerformanceListComponent },
-  { path: 'festivals/:id/performances/new', component: PerformanceCreateComponent },
+  { path: 'festivals/:id/stages', component: StageListComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/stages/new', component: StageCreateComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/performances', component: PerformanceListComponent, canActivate: [adminGuard] },
+  { path: 'festivals/:id/performances/new', component: PerformanceCreateComponent, canActivate: [adminGuard] },
   { path: '**', redirectTo: '' },
 ];
 

--- a/music-festival-planner/src/app/app.html
+++ b/music-festival-planner/src/app/app.html
@@ -25,10 +25,7 @@
       <li class="nav-item" *ngIf="authService.isLoggedIn">
         <span class="nav-link text-muted">{{ authService.currentUser?.email }}</span>
       </li>
-      <li class="nav-item" *ngIf="!authService.isLoggedIn">
-        <a class="nav-link" routerLink="/login">Sign In</a>
-      </li>
-      <li class="nav-item" *ngIf="authService.isLoggedIn">
+<li class="nav-item" *ngIf="authService.isLoggedIn">
         <button class="btn btn-link nav-link" (click)="logout()">Sign Out</button>
       </li>
     </ul>

--- a/music-festival-planner/src/app/components/festivals/festivals.html
+++ b/music-festival-planner/src/app/components/festivals/festivals.html
@@ -1,7 +1,9 @@
 <div class="festivals-container" (click)="closeAllKebabMenus()">
   <nav class="page-nav">
     <h1 id="festivals-heading">Music Festivals</h1>
-    <button class="btn-primary" routerLink="/festivals/create">+ Add New Festival</button>
+    @if (isOrganizerUser) {
+      <button class="btn-primary" routerLink="/festivals/create">+ Add New Festival</button>
+    }
   </nav>
 
   <div class="card-grid" role="list" aria-labelledby="festivals-heading">
@@ -162,9 +164,14 @@
 
   @if (festivalsList.length === 0) {
     <div class="empty-state">
-      <h2>No festivals yet</h2>
-      <p>Add your first festival to start building schedules, stages, and performances.</p>
-      <button class="btn-primary" routerLink="/festivals/create">Create your first festival</button>
+      @if (isOrganizerUser) {
+        <h2>No festivals yet</h2>
+        <p>Add your first festival to start building schedules, stages, and performances.</p>
+        <button class="btn-primary" routerLink="/festivals/create">Create your first festival</button>
+      } @else {
+        <h2>No festivals yet</h2>
+        <p>Check back soon — festivals will be listed here once they are added.</p>
+      }
     </div>
   }
 </div>


### PR DESCRIPTION
- Remove Sign In link from navbar so the login page is not discoverable by public users (admins navigate to /login directly)
- Add adminGuard to festivals/create, festivals/:id/stages, festivals/:id/stages/new, festivals/:id/performances, and festivals/:id/performances/new routes so only admins can reach them
- Hide + Add New Festival button and empty-state create button from non-admin users in the festivals page
- Add backend/scripts/seed-admin.js to create or promote an admin account via ADMIN_EMAIL and ADMIN_PASSWORD env vars, plus a seed:admin npm script to run it

https://claude.ai/code/session_01T8iXFEuLauZdGpfSbDw2Bt