### PR TITLE
Add password visibility toggle to login form

### DIFF
--- a/music-festival-planner/src/app/components/login/login.css
+++ b/music-festival-planner/src/app/components/login/login.css
@@ -9,3 +9,25 @@
   width: 100%;
   max-width: 420px;
 }
+
+.password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-field .form-control {
+  padding-right: 2.75rem;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.6rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  color: inherit;
+}

--- a/music-festival-planner/src/app/components/login/login.html
+++ b/music-festival-planner/src/app/components/login/login.html
@@ -25,15 +25,25 @@
 
         <div class="mb-4">
           <label for="password" class="form-label">Password</label>
-          <input
-            id="password"
-            type="password"
-            class="form-control"
-            [class.is-invalid]="form.get('password')?.invalid && form.get('password')?.touched"
-            formControlName="password"
-            autocomplete="current-password"
-          />
-          <div class="invalid-feedback">
+          <div class="password-field">
+            <input
+              id="password"
+              [type]="showPassword ? 'text' : 'password'"
+              class="form-control"
+              [class.is-invalid]="form.get('password')?.invalid && form.get('password')?.touched"
+              formControlName="password"
+              autocomplete="current-password"
+            />
+            <button
+              type="button"
+              class="password-toggle"
+              (click)="showPassword = !showPassword"
+              [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'"
+            >
+              {{ showPassword ? '🙈' : '👁️' }}
+            </button>
+          </div>
+          <div class="invalid-feedback" [class.d-block]="form.get('password')?.invalid && form.get('password')?.touched">
             Password must be at least 8 characters.
           </div>
         </div>

--- a/music-festival-planner/src/app/components/login/login.ts
+++ b/music-festival-planner/src/app/components/login/login.ts
@@ -13,6 +13,7 @@ export class LoginComponent implements OnInit {
   form!: FormGroup;
   errorMessage = '';
   isLoading = false;
+  showPassword = false;
 
   constructor(
     private fb: FormBuilder,


### PR DESCRIPTION
This pull request enhances the login form by adding a user-friendly "show/hide password" feature. The main updates include introducing a toggle button to reveal or mask the password input, updating the form control logic, and adding supporting styles for the new UI elements.

**User experience improvements:**

* Added a "show/hide password" toggle button to the password input field in the login form, allowing users to view or mask their password as needed. The button updates its icon and ARIA label for accessibility. (`login.html`, `login.ts`) [[1]](diffhunk://#diff-4cf9d46d2d1ee27921f67915dca1e2f60d9f8ba089284df7a12a5768b3027226R28-R46) [[2]](diffhunk://#diff-560a18c134c79294acb07b4903feda91bb22b2032b8a8b51def36607a2ad6a7fR16)

**Styling updates:**

* Introduced new CSS classes (`.password-field`, `.password-toggle`) to style the password input and toggle button, ensuring proper alignment and appearance in the login form. (`login.css`)https://claude.ai/code/session_01T8iXFEuLauZdGpfSbDw2Bt