### PR TITLE
Add diagnostic script for verifying admin accounts in database

### DIFF
--- a/music-festival-planner/backend/scripts/check-admin.js
+++ b/music-festival-planner/backend/scripts/check-admin.js
@@ -1,0 +1,33 @@
+const { connectToDatabase, disconnectFromDatabase } = require('../config/database');
+const User = require('../models/user');
+
+async function run() {
+  await connectToDatabase();
+
+  const email = process.env.ADMIN_EMAIL || 'your@email.com';
+
+  // Must explicitly select password since it has select:false on the schema
+  const user = await User.findOne({ email }).select('+password');
+
+  if (!user) {
+    console.log(`No user found for email: ${email}`);
+    await disconnectFromDatabase();
+    return;
+  }
+
+  console.log(`Found user: ${user.email}, role: ${user.role}`);
+  console.log(`Password hash stored: ${user.password}`);
+
+  const testPassword = process.env.ADMIN_PASSWORD;
+  if (testPassword) {
+    const match = await user.comparePassword(testPassword);
+    console.log(`Password "${testPassword}" matches: ${match}`);
+  }
+
+  await disconnectFromDatabase();
+}
+
+run().catch((err) => {
+  console.error('check-admin failed:', err.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
This pull request adds a new script to help verify the existence and credentials of an admin user in the database. The script connects to the database, looks up a user by email, and optionally checks if a provided password matches the stored hash.

**New admin verification script:**

* Added `check-admin.js` script that:
  * Connects to the database and looks up a user by email (from `ADMIN_EMAIL` environment variable or default).
  * Explicitly selects the password field for verification.
  * Prints user information and password hash if found.
  * Optionally checks if a provided password (from `ADMIN_PASSWORD` environment variable) matches the stored hash.
  * Handles errors and ensures the database connection is closed

https://claude.ai/code/session_01T8iXFEuLauZdGpfSbDw2Bt